### PR TITLE
option to exclude some nodes (i.e. the faulty nodes) from the computa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Our current system places `ckpt` files to indicate that a job has finished in th
 A [Nuke Checkpoints](scripts/nuke_checkpoints.py) script is provided for ease of removing checkpoint files. To use, pass a directory location as the launch parameter and the script will remove checkpoint files from the directory and all sub-directories.
 
 # FAQ
+## How can I exclude some nodes?
+
+You can use the exclude_list parameter as a workflow parameter (or resource parameter) to exclude some nodes. This is useful if some nodes are not properly configured or donot have the features you expect but otherwise are ready to be used.
+
+## How can I run my pipeline on one specific node?
+Use run_on_single_node parameter when you initialize a workflow (or a Slurm resource) to specify a single node to run your pipeline (or a single step of your pipeline) on a single node. 
+* Note you cannot use this option with the **exclude_list** option.
+* Note you cannot specify more than one node using this option.
 
 ## What are valid root directories for the workflow?
 
@@ -60,17 +68,9 @@ The experiment directory can be (and ought to be) on such a drive, though.
 
 Partitions each have a max walltime associated with them. See the saga cluster wiki [here]("https://github.com/isi-vista/saga-cluster/wiki/How-to-use-the-SAGA-queue#partitions"). If you specify a partition with a `job_time_in_minutes` greater than that partition's max walltime, you will see an error. 
 
-## `Error parsing classad or job not found`
-
-An annoying error that says very little about what might be going on. In the past, has been associated with the workflow requesting too little memory resulting in an `OUT_OF_ME+` on SLURM. See Debugging Tricks/Tips for ways to confirm this.
-
 # Contributing
 
 Run `make precommit` before commiting.  
 
 If you are using PyCharm, please set your docstring format to "Google" and your unit test runner to "PyTest"
 in `Preferences | Tools | Python Integrated Tools`.
-
-## Debugging Tricks/Tips
-
-* Investigate reasons for why a job is in a certain state (like being held for way too long): `condor_q -long [job_id]`. You can get the job id by `pegasus-status -v [wfdir]`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Our current system places `ckpt` files to indicate that a job has finished in th
 A [Nuke Checkpoints](scripts/nuke_checkpoints.py) script is provided for ease of removing checkpoint files. To use, pass a directory location as the launch parameter and the script will remove checkpoint files from the directory and all sub-directories.
 
 # FAQ
+
+## What are valid root directories for the workflow?
+
+Currently the root directory should be be in your home directory and not on an NAS like `/nas/gaia/` as the submission will fail for an NFS reason.
+The experiment directory can be (and ought to be) on such a drive, though.
+
 ## How can I exclude some nodes?
 
 You can use the exclude_list parameter as a workflow parameter (or resource parameter) to exclude some nodes. This is useful if some nodes are not properly configured or donot have the features you expect but otherwise are ready to be used.
@@ -57,10 +63,6 @@ Use run_on_single_node parameter when you initialize a workflow (or a Slurm reso
 * Note you cannot use this option with the **exclude_list** option.
 * Note you cannot specify more than one node using this option.
 
-## What are valid root directories for the workflow?
-
-Currently the root directory should be be in your home directory and not on an NAS like `/nas/gaia/` as the submission will fail for an NFS reason.
-The experiment directory can be (and ought to be) on such a drive, though.
 
 # Common Errors
 
@@ -68,9 +70,17 @@ The experiment directory can be (and ought to be) on such a drive, though.
 
 Partitions each have a max walltime associated with them. See the saga cluster wiki [here]("https://github.com/isi-vista/saga-cluster/wiki/How-to-use-the-SAGA-queue#partitions"). If you specify a partition with a `job_time_in_minutes` greater than that partition's max walltime, you will see an error. 
 
+## `Error parsing classad or job not found`
+
+An annoying error that says very little about what might be going on. In the past, has been associated with the workflow requesting too little memory resulting in an `OUT_OF_ME+` on SLURM. See Debugging Tricks/Tips for ways to confirm this.
+
 # Contributing
 
 Run `make precommit` before commiting.  
 
 If you are using PyCharm, please set your docstring format to "Google" and your unit test runner to "PyTest"
 in `Preferences | Tools | Python Integrated Tools`.
+
+## Debugging Tricks/Tips
+
+* Investigate reasons for why a job is in a certain state (like being held for way too long): `condor_q -long [job_id]`. You can get the job id by `pegasus-status -v [wfdir]`.

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ Our current system places `ckpt` files to indicate that a job has finished in th
 A [Nuke Checkpoints](scripts/nuke_checkpoints.py) script is provided for ease of removing checkpoint files. To use, pass a directory location as the launch parameter and the script will remove checkpoint files from the directory and all sub-directories.
 
 # FAQ
-
-## What are valid root directories for the workflow?
-
-Currently the root directory should be be in your home directory and not on an NAS like `/nas/gaia/` as the submission will fail for an NFS reason.
-The experiment directory can be (and ought to be) on such a drive, though.
-
 ## How can I exclude some nodes?
 
 You can use the exclude_list parameter as a workflow parameter (or resource parameter) to exclude some nodes. This is useful if some nodes are not properly configured or donot have the features you expect but otherwise are ready to be used.
@@ -63,6 +57,10 @@ Use run_on_single_node parameter when you initialize a workflow (or a Slurm reso
 * Note you cannot use this option with the **exclude_list** option.
 * Note you cannot specify more than one node using this option.
 
+## What are valid root directories for the workflow?
+
+Currently the root directory should be be in your home directory and not on an NAS like `/nas/gaia/` as the submission will fail for an NFS reason.
+The experiment directory can be (and ought to be) on such a drive, though.
 
 # Common Errors
 
@@ -70,17 +68,9 @@ Use run_on_single_node parameter when you initialize a workflow (or a Slurm reso
 
 Partitions each have a max walltime associated with them. See the saga cluster wiki [here]("https://github.com/isi-vista/saga-cluster/wiki/How-to-use-the-SAGA-queue#partitions"). If you specify a partition with a `job_time_in_minutes` greater than that partition's max walltime, you will see an error. 
 
-## `Error parsing classad or job not found`
-
-An annoying error that says very little about what might be going on. In the past, has been associated with the workflow requesting too little memory resulting in an `OUT_OF_ME+` on SLURM. See Debugging Tricks/Tips for ways to confirm this.
-
 # Contributing
 
 Run `make precommit` before commiting.  
 
 If you are using PyCharm, please set your docstring format to "Google" and your unit test runner to "PyTest"
 in `Preferences | Tools | Python Integrated Tools`.
-
-## Debugging Tricks/Tips
-
-* Investigate reasons for why a job is in a certain state (like being held for way too long): `condor_q -long [job_id]`. You can get the job id by `pegasus-status -v [wfdir]`.

--- a/pegasus_wrapper/__init__.py
+++ b/pegasus_wrapper/__init__.py
@@ -24,6 +24,7 @@ from pegasus_wrapper.locator import Locator
 from pegasus_wrapper.resource_request import ResourceRequest
 from pegasus_wrapper.version import version as __version__  # noqa
 from pegasus_wrapper.workflow import WorkflowBuilder
+
 from saga_tools.conda import CondaConfiguration
 
 _SINGLETON_WORKFLOW_BUILDER: WorkflowBuilder = None  # type: ignore

--- a/pegasus_wrapper/resource_request.py
+++ b/pegasus_wrapper/resource_request.py
@@ -96,7 +96,7 @@ class SlurmResourceRequest(ResourceRequest):
     )
 
     @run_on_single_node.validator
-    def check(self, *, value: str):
+    def check(self, _, value: str):
         if value:
             if len(value.split(",")) != 1:
                 raise ValueError("run_on_single_node parameter must provide only node!")

--- a/pegasus_wrapper/resource_request.py
+++ b/pegasus_wrapper/resource_request.py
@@ -96,7 +96,7 @@ class SlurmResourceRequest(ResourceRequest):
     )
 
     @run_on_single_node.validator
-    def check(self, attribute, value: str):
+    def check(self, *, value: str):
         if value:
             if len(value.split(",")) != 1:
                 raise ValueError("run_on_single_node parameter must provide only node!")

--- a/pegasus_wrapper/workflow.py
+++ b/pegasus_wrapper/workflow.py
@@ -15,7 +15,6 @@ from vistautils.class_utils import fully_qualified_name
 from vistautils.io_utils import CharSink
 from vistautils.parameters import Parameters, YAMLParametersWriter
 
-from Pegasus.DAX3 import ADAG, Executable, File, Job, Link, Namespace
 from pegasus_wrapper import resources
 from pegasus_wrapper.artifact import DependencyNode, _canonicalize_depends_on
 from pegasus_wrapper.conda_job_script import CondaJobScriptGenerator
@@ -26,6 +25,8 @@ from pegasus_wrapper.pegasus_utils import (
     path_to_pfn,
 )
 from pegasus_wrapper.resource_request import ResourceRequest
+
+from Pegasus.DAX3 import ADAG, Executable, File, Job, Link, Namespace
 from saga_tools.conda import CondaConfiguration
 
 try:

--- a/tests/workflow_builder_test.py
+++ b/tests/workflow_builder_test.py
@@ -487,6 +487,7 @@ def test_dax_test_exclude_nodes_on_saga(tmp_path):
     multiply_params = Parameters.from_mapping(
         {"input_file": multiply_input_file, "output_file": multiply_output_file, "x": 4}
     )
+
     sort_params = Parameters.from_mapping(
         {"input_file": multiply_output_file, "output_file": sorted_output_file}
     )

--- a/tests/workflow_builder_test.py
+++ b/tests/workflow_builder_test.py
@@ -459,7 +459,7 @@ def test_category_max_jobs(tmp_path):
 def test_dax_test_exclude_nodes_on_saga(tmp_path):
 
     sample_exclude = "saga01,saga03,saga21,saga05"
-    sample_include = "saga03"
+    sample_include = "saga06"
 
     params = Parameters.from_mapping(
         {
@@ -525,9 +525,8 @@ def test_dax_test_exclude_nodes_on_saga(tmp_path):
                     if item2.attrib["namespace"] == "pegasus":
                         if item.attrib["name"] == "jobs_multiply":
                             assert f"--exclude={sample_exclude}" in item2.text
-                            assert f"--nodelist={sample_include}" not in item2.text
                         elif item.attrib["name"] == "jobs_sort":
-                            assert f"--exclude=" not in item2.text
+                            assert f"--exclude=" in item2.text
                             assert f"--nodelist={sample_include}" in item2.text
                         else:
                             assert False


### PR DESCRIPTION
Right now, the wrapper assigns the jobs to all available nodes. This causes the pipeline to break if some nodes are faulty. By adding an additional option "exclude_list" to the param file you can exclude some nodes (exclude_list: eg_node_0,eg_node_1,eg_node_3).

