### PR TITLE
Add experiment_name to job identifier; minor refactorings

### DIFF
--- a/pegasus_wrapper/resource_request.py
+++ b/pegasus_wrapper/resource_request.py
@@ -97,9 +97,8 @@ class SlurmResourceRequest(ResourceRequest):
 
     @run_on_single_node.validator
     def check(self, _, value: str):
-        if value:
-            if len(value.split(",")) != 1:
-                raise ValueError("run_on_single_node parameter must provide only node!")
+        if value and len(value.split(",")) != 1:
+            raise ValueError("run_on_single_node parameter must provide only node!")
 
     @staticmethod
     def from_parameters(params: Parameters) -> ResourceRequest:

--- a/pegasus_wrapper/resource_request.py
+++ b/pegasus_wrapper/resource_request.py
@@ -163,11 +163,14 @@ class SlurmResourceRequest(ResourceRequest):
             ),
         )
 
-        if self.exclude_list and self.run_on_single_node:
-            if self.run_on_single_node in self.exclude_list:
-                raise ValueError(
-                    "the 'exclude_list' and 'run_on_single_node' options are not consistent."
-                )
+        if (
+            self.exclude_list
+            and self.run_on_single_node
+            and self.run_on_single_node in self.exclude_list
+        ):
+            raise ValueError(
+                "the 'exclude_list' and 'run_on_single_node' options are not consistent."
+            )
 
         if self.exclude_list:
             slurm_resource_content += f" --exclude={self.exclude_list}"

--- a/pegasus_wrapper/workflow.py
+++ b/pegasus_wrapper/workflow.py
@@ -72,7 +72,9 @@ class WorkflowBuilder:
     # Path to the replica catalog to store checkpointed files
     _replica_catalog: Path = attrib(validator=instance_of(Path))
     _category_to_max_jobs: Dict[str, int] = attrib(factory=dict)
-    # Call include an experiment_name so that jobs are more identifiable on SAGA
+    # Include an experiment_name so that jobs are more identifiable on SAGA,
+    # opting for experiment_name over workflow_name bc of VISTA's use of
+    # the same or similar workflow with multiple experiments
     _experiment_name: str = attrib(kw_only=True, default="")
 
     @staticmethod

--- a/pegasus_wrapper/workflow.py
+++ b/pegasus_wrapper/workflow.py
@@ -106,9 +106,12 @@ class WorkflowBuilder:
         return ret
 
     def _job_name_for(self, locator: Locator) -> str:
-        locater_as_name = str(locator).replace('/', '_')
-        return f"{self._experiment_name}_{locater_as_name}" if self._experiment_name else locater_as_name
-            
+        locater_as_name = str(locator).replace("/", "_")
+        return (
+            f"{self._experiment_name}_{locater_as_name}"
+            if self._experiment_name
+            else locater_as_name
+        )
 
     def run_python_on_parameters(
         self,

--- a/pegasus_wrapper/workflow.py
+++ b/pegasus_wrapper/workflow.py
@@ -72,6 +72,8 @@ class WorkflowBuilder:
     # Path to the replica catalog to store checkpointed files
     _replica_catalog: Path = attrib(validator=instance_of(Path))
     _category_to_max_jobs: Dict[str, int] = attrib(factory=dict)
+    # Call include an experiment_name so that jobs are more identifiable on SAGA
+    _experiment_name: str = attrib(kw_only=True, default="")
 
     @staticmethod
     def from_parameters(params: Parameters) -> "WorkflowBuilder":
@@ -90,6 +92,7 @@ class WorkflowBuilder:
             conda_script_generator=CondaJobScriptGenerator.from_parameters(params),
             namespace=params.string("namespace"),
             default_resource_request=ResourceRequest.from_parameters(params),
+            experiment_name=params.string("experiment_name", default=""),
             replica_catalog=replica_catalog,
         )
 
@@ -103,7 +106,9 @@ class WorkflowBuilder:
         return ret
 
     def _job_name_for(self, locator: Locator) -> str:
-        return str(locator).replace("/", "_")
+        locater_as_name = str(locator).replace('/', '_')
+        return f"{self._experiment_name}_{locater_as_name}" if self._experiment_name else locater_as_name
+            
 
     def run_python_on_parameters(
         self,
@@ -164,7 +169,7 @@ class WorkflowBuilder:
         )
         script_executable = Executable(
             namespace=self._namespace,
-            name=str(job_name).replace("/", "_"),
+            name=self._job_name_for(job_name),
             version="4.0",
             os="linux",
             arch="x86_64",

--- a/tests/workflow_builder_test.py
+++ b/tests/workflow_builder_test.py
@@ -28,7 +28,7 @@ def test_simple_dax(tmp_path):
             "site": "saga",
             "namespace": "test",
             "partition": "scavenge",
-            "experiment_name": "fred"
+            "experiment_name": "fred",
         }
     )
     workflow_builder = WorkflowBuilder.from_parameters(params)
@@ -42,7 +42,7 @@ def test_simple_dax(tmp_path):
     assert workflow_builder._default_site == "saga"  # pylint:disable=protected-access
     assert workflow_builder.default_resource_request  # pylint:disable=protected-access
     assert workflow_builder._job_graph is not None  # pylint:disable=protected-access
-    assert workflow_builder._experiment_name == "fred" # pylint:disable=protected-access
+    assert workflow_builder._experiment_name == "fred"  # pylint:disable=protected-access
 
 
 def test_locator():
@@ -66,7 +66,7 @@ def test_dax_with_job_on_saga(tmp_path):
             "site": "saga",
             "namespace": "test",
             "partition": "scavenge",
-            "experiment_name": "fred"
+            "experiment_name": "fred",
         }
     )
     slurm_params = Parameters.from_mapping(

--- a/tests/workflow_builder_test.py
+++ b/tests/workflow_builder_test.py
@@ -28,6 +28,7 @@ def test_simple_dax(tmp_path):
             "site": "saga",
             "namespace": "test",
             "partition": "scavenge",
+            "experiment_name": "fred"
         }
     )
     workflow_builder = WorkflowBuilder.from_parameters(params)
@@ -41,6 +42,7 @@ def test_simple_dax(tmp_path):
     assert workflow_builder._default_site == "saga"  # pylint:disable=protected-access
     assert workflow_builder.default_resource_request  # pylint:disable=protected-access
     assert workflow_builder._job_graph is not None  # pylint:disable=protected-access
+    assert workflow_builder._experiment_name == "fred" # pylint:disable=protected-access
 
 
 def test_locator():
@@ -64,6 +66,7 @@ def test_dax_with_job_on_saga(tmp_path):
             "site": "saga",
             "namespace": "test",
             "partition": "scavenge",
+            "experiment_name": "fred"
         }
     )
     slurm_params = Parameters.from_mapping(
@@ -72,7 +75,7 @@ def test_dax_with_job_on_saga(tmp_path):
     multiply_input_file = tmp_path / "raw_nums.txt"
     random = Random()
     random.seed(0)
-    nums = immutableset(int(random.random() * 100) for _ in range(0, 25))
+    nums = immutableset(int(random.random() * 100) for _ in range(25))
     multiply_output_file = tmp_path / "multiplied_nums.txt"
     sorted_output_file = tmp_path / "sorted_nums.txt"
     with multiply_input_file.open("w") as mult_file:
@@ -88,6 +91,7 @@ def test_dax_with_job_on_saga(tmp_path):
     workflow_builder = WorkflowBuilder.from_parameters(workflow_params)
 
     multiply_job_name = Locator(_parse_parts("jobs/multiply"))
+
     multiply_artifact = ValueArtifact(
         multiply_output_file,
         depends_on=workflow_builder.run_python_on_parameters(


### PR DESCRIPTION
Would like to hear people's thoughts on this. 

Jobs would be more easily identifiable if they incorporated an experiment name. For me, seeing a bunch of jobs on SAGA called `corpora_` isn't helpful at a glance especially if I'm running multiple Pegasus pipelines. It's convenience more than anything.